### PR TITLE
#5

### DIFF
--- a/opensilex-sparql/src/main/java/org/opensilex/sparql/mapping/SPARQLClassQueryBuilder.java
+++ b/opensilex-sparql/src/main/java/org/opensilex/sparql/mapping/SPARQLClassQueryBuilder.java
@@ -323,9 +323,7 @@ public class SPARQLClassQueryBuilder {
         tripleHandler.accept(new Triple(uriNode, RDF.type.asNode(), analyzer.getRDFType().asNode()), analyzer.getURIField());
 
         for (Field field : analyzer.getDataPropertyFields()) {
-            Method method = analyzer.getGetterFromField(field);
-            // prevent NullPointerException if the method is not found from the analyser
-            Object fieldValue = method != null ? method.invoke(instance) : null;
+            Object fieldValue = analyzer.getGetterFromField(field).invoke(instance);
 
             if (fieldValue == null) {
                 if (!ignoreNullFields && !analyzer.isOptional(field)) {
@@ -340,8 +338,7 @@ public class SPARQLClassQueryBuilder {
         }
 
         for (Field field : analyzer.getObjectPropertyFields()) {
-            Method method = analyzer.getGetterFromField(field);
-            Object fieldValue = method != null ? method.invoke(instance) : null;
+            Object fieldValue = analyzer.getGetterFromField(field).invoke(instance);
 
             if (fieldValue == null) {
                 if (!ignoreNullFields && !analyzer.isOptional(field)) {
@@ -361,8 +358,7 @@ public class SPARQLClassQueryBuilder {
         }
 
         for (Field field : analyzer.getDataListPropertyFields()) {
-            Method method = analyzer.getGetterFromField(field);
-            List<?> fieldValues = method != null ? (List<?>) method.invoke(instance) : null;
+            List<?> fieldValues = (List<?>) analyzer.getGetterFromField(field).invoke(instance);
 
             if (fieldValues != null) {
                 Property property = analyzer.getDataListPropertyByField(field);
@@ -375,8 +371,7 @@ public class SPARQLClassQueryBuilder {
         }
 
         for (Field field : analyzer.getObjectListPropertyFields()) {
-            Method method = analyzer.getGetterFromField(field);
-            List<?> fieldValues = method != null ? (List<?>) method.invoke(instance) : null;
+            List<?> fieldValues = (List<?>) analyzer.getGetterFromField(field).invoke(instance);
 
             if (fieldValues != null) {
                 for (Object listValue : fieldValues) {

--- a/opensilex-sparql/src/main/java/org/opensilex/sparql/mapping/SPARQLProxyListObject.java
+++ b/opensilex-sparql/src/main/java/org/opensilex/sparql/mapping/SPARQLProxyListObject.java
@@ -33,17 +33,14 @@ public class SPARQLProxyListObject<T extends SPARQLResourceModel> extends SPARQL
         SPARQLClassObjectMapper<T> sparqlObjectMapper = SPARQLClassObjectMapper.getForClass(genericType);
         
         Node nodeURI = SPARQLDeserializers.nodeURI(uri);
-        List<T> results = service.search(genericType, (SelectBuilder select) -> {
+        return service.search(genericType, (SelectBuilder select) -> {
             if (isReverseRelation) {
-                select.addWhere(makeVar(sparqlObjectMapper.getURIFieldName()), property, nodeURI);
+                select.addGraph(graph, makeVar(sparqlObjectMapper.getURIFieldName()), property, nodeURI);
             } else {
-                select.addWhere(nodeURI, property, makeVar(sparqlObjectMapper.getURIFieldName()));
+                select.addGraph(graph, nodeURI, property, makeVar(sparqlObjectMapper.getURIFieldName()));
             }
-            
         });
-
-        return results;
     }
 
-    
+
 }


### PR DESCRIPTION
Signed-off-by: renaud colin <renaud.colin@inra.fr>

- Update the `SelectBuilder.getCountBuilder() and SelectBuilder.getSelectBuilder()` method by taking care to specify the GRAPH clause only for the WHERE parts.
- Update the `SPARQLProxyListObject.loadData()` method by specifying the graph to query when adding a property between two `SPARQLResourceModel`