### PR TITLE
Sparql query helper

### DIFF
--- a/opensilex-sparql/src/main/java/org/opensilex/sparql/service/SPARQLQueryHelper.java
+++ b/opensilex-sparql/src/main/java/org/opensilex/sparql/service/SPARQLQueryHelper.java
@@ -126,7 +126,7 @@ public class SPARQLQueryHelper {
      *         null if sparqlVarName is empty or null or if object is null
      * @see ExprFactory#eq(Object, Object)
      */
-    public static Expr eq(String sparqlVarName, Node node) {
+    public static E_Equals eq(String sparqlVarName, Node node) {
 
         if (StringUtils.isEmpty(sparqlVarName) || node == null) {
             return null;

--- a/opensilex-sparql/src/main/java/org/opensilex/sparql/service/SPARQLQueryHelper.java
+++ b/opensilex-sparql/src/main/java/org/opensilex/sparql/service/SPARQLQueryHelper.java
@@ -45,7 +45,7 @@ public class SPARQLQueryHelper {
 
     public static final Var typeDefVar = makeVar("__type");
 
-    public static <T> Var getUriFieldVar(Class<T> objectClass) throws SPARQLMapperNotFoundException, SPARQLInvalidClassDefinitionException {
+    public final static <T> Var getUriFieldVar(Class<T> objectClass) throws SPARQLMapperNotFoundException, SPARQLInvalidClassDefinitionException {
         SPARQLClassObjectMapper<SPARQLResourceModel> mapper = SPARQLClassObjectMapper.getForClass(objectClass);
         return makeVar(mapper.getURIFieldName());
     }

--- a/opensilex-sparql/src/main/java/org/opensilex/sparql/service/SPARQLQueryHelper.java
+++ b/opensilex-sparql/src/main/java/org/opensilex/sparql/service/SPARQLQueryHelper.java
@@ -5,17 +5,32 @@
  */
 package org.opensilex.sparql.service;
 
-import static org.apache.jena.arq.querybuilder.AbstractQueryBuilder.makeVar;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.arq.querybuilder.ExprFactory;
+import org.apache.jena.arq.querybuilder.SelectBuilder;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.expr.E_LogicalAnd;
 import org.apache.jena.sparql.expr.E_LogicalOr;
 import org.apache.jena.sparql.expr.E_Regex;
 import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.ExprVar;
+import org.apache.jena.sparql.expr.E_Equals;
+import org.apache.jena.sparql.expr.E_GreaterThanOrEqual;
+import org.apache.jena.sparql.expr.E_LessThanOrEqual;
+import org.opensilex.sparql.deserializer.DateDeserializer;
+import org.opensilex.sparql.deserializer.SPARQLDeserializer;
+import org.opensilex.sparql.deserializer.SPARQLDeserializerNotFoundException;
+import org.opensilex.sparql.deserializer.SPARQLDeserializers;
 import org.opensilex.sparql.exceptions.SPARQLInvalidClassDefinitionException;
 import org.opensilex.sparql.exceptions.SPARQLMapperNotFoundException;
 import org.opensilex.sparql.mapping.SPARQLClassObjectMapper;
 import org.opensilex.sparql.model.SPARQLResourceModel;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+import static org.apache.jena.arq.querybuilder.AbstractQueryBuilder.makeVar;
 
 /**
  *
@@ -26,12 +41,14 @@ public class SPARQLQueryHelper {
     private SPARQLQueryHelper() {
     }
 
+    protected static final ExprFactory exprFactory = new ExprFactory();
+
     public static final Var typeDefVar = makeVar("__type");
-    
-    public static final <T> Var getUriFieldVar(Class<T> objectClass) throws SPARQLMapperNotFoundException, SPARQLInvalidClassDefinitionException {
+
+    public static <T> Var getUriFieldVar(Class<T> objectClass) throws SPARQLMapperNotFoundException, SPARQLInvalidClassDefinitionException {
         SPARQLClassObjectMapper<SPARQLResourceModel> mapper = SPARQLClassObjectMapper.getForClass(objectClass);
         return makeVar(mapper.getURIFieldName());
-    };
+    }
 
     public static Expr regexFilter(String fieldName, String regexPattern) {
         return regexFilter(fieldName, regexPattern, null);
@@ -47,9 +64,7 @@ public class SPARQLQueryHelper {
         }
 
         ExprVar name = new ExprVar(fieldName);
-        Expr filter = new E_Regex(name, regexPattern, regexFlag);
-
-        return filter;
+        return new E_Regex(name, regexPattern, regexFlag);
     }
 
     public static Expr or(Expr... expressions) {
@@ -82,5 +97,117 @@ public class SPARQLQueryHelper {
         }
 
         return parentExpr;
+    }
+
+    /**
+     * @param sparqlVarName the variable name
+     * @param object the object to compare with the given variable
+     * @return an E_Equals expression between the given variable and the given object,
+     *         null if sparqlVarName is empty or null or if object is null
+     *
+     * @throws SPARQLDeserializerNotFoundException if no {@link SPARQLDeserializer} is found for object
+     * 
+     * @see ExprFactory#eq(Object, Object)
+     * @see SPARQLDeserializers#getForClass(Class)
+     */
+    public static E_Equals eq(String sparqlVarName, Object object) throws Exception {
+
+        if (StringUtils.isEmpty(sparqlVarName) || object == null) {
+            return null;
+        }
+        Node node = SPARQLDeserializers.getForClass(object.getClass()).getNode(object);
+        return exprFactory.eq(NodeFactory.createVariable(sparqlVarName), node);
+    }
+
+    /**
+     * @param sparqlVarName the variable name
+     * @param node the Jena node to compare with the given variable
+     * @return an E_Equals expression between the given variable and the given object,
+     *         null if sparqlVarName is empty or null or if object is null
+     * @see ExprFactory#eq(Object, Object)
+     */
+    public static Expr eq(String sparqlVarName, Node node) {
+
+        if (StringUtils.isEmpty(sparqlVarName) || node == null) {
+            return null;
+        }
+        return exprFactory.eq(NodeFactory.createVariable(sparqlVarName), node);
+    }
+
+    /**
+     * Append a VALUES clause to the given select if values and sparqlVarName are not empty,
+     *
+     * @param select        the SelectBuilder to update
+     * @param sparqlVarName the name of the SPARQL variable
+     * @param values        the list of values to put in the VALUES set
+     *
+     * @throws NullPointerException if select, varName or values are null
+     * @throws SPARQLDeserializerNotFoundException  if no {@link SPARQLDeserializer} is found for an element of values
+     *
+     * @see <a href=www.w3.org/TR/2013/REC-sparql11-query-20130321/#inline-data>W3C SPARQL VALUES specifications</a>
+     * @see SelectBuilder#addWhereValueVar(Object, Object...)
+     * @see SPARQLDeserializers#getForClass(Class)
+     */
+    public static void addWhereValues(SelectBuilder select, String sparqlVarName, List<?> values) throws Exception {
+
+        Objects.requireNonNull(select);
+        Objects.requireNonNull(values);
+        Objects.requireNonNull(sparqlVarName);
+
+        if (values.isEmpty() || sparqlVarName.isEmpty())
+           return;
+
+        // convert list to JENA node array and return the new SelectBuilder
+        Object[] nodes = new Node[values.size()];
+        int i = 0;
+        for (Object object : values) {
+            nodes[i++] = SPARQLDeserializers.getForClass(object.getClass()).getNode(object);
+        }
+        select.addWhereValueVar(sparqlVarName, nodes);
+    }
+
+    /**
+     * @param startDateSparqlVarName : the name of the startDate SPARQL variable , should not be null if startDate is not null
+     * @param startDate              : the start date
+     * @param endDateSparqlVarName   : the name of the endDate SPARQL variable , should not be null if endDate is not null
+     * @param endDate                : the end date
+     * @return an Expr with the two given LocalDate and the two SPARQL variables
+     * <pre>
+     *     null if startDate and endDate are both null
+     *     an {@link E_LogicalAnd} if startDate and endDate are both non null
+     *     an {@link E_GreaterThanOrEqual} if only startDate is not null
+     *     an {@link E_LessThanOrEqual} if only endDate is not null
+     * </pre>
+     * @see ExprFactory#and(Object, Object)
+     * @see ExprFactory#le(Object, Object)
+     * @see ExprFactory#ge(Object, Object)
+     */
+    public static Expr dateRange(String startDateSparqlVarName, LocalDate startDate, String endDateSparqlVarName, LocalDate endDate) throws Exception {
+
+        boolean startDateNull = startDate == null;
+        boolean endDateNull = endDate == null;
+        if (startDateNull && endDateNull) {
+            return null;
+        }
+
+        DateDeserializer dateDeserializer = new DateDeserializer();
+        Node endVar;
+        Expr endDateExpr = null;
+
+        if (!endDateNull) {
+            endVar = NodeFactory.createVariable(endDateSparqlVarName);
+            endDateExpr = exprFactory.le(endVar, dateDeserializer.getNode(endDate));
+        }
+
+        if (!startDateNull) {
+            Node startVar = NodeFactory.createVariable(startDateSparqlVarName);
+            Expr startDateExpr = exprFactory.ge(startVar, dateDeserializer.getNode(startDate));
+
+            if (!endDateNull) {
+                return exprFactory.and(startDateExpr, endDateExpr);
+            }
+            return startDateExpr;
+        }
+        return endDateExpr;
     }
 }

--- a/opensilex-sparql/src/test/java/org/opensilex/sparql/service/SPARQLQueryHelperTest.java
+++ b/opensilex-sparql/src/test/java/org/opensilex/sparql/service/SPARQLQueryHelperTest.java
@@ -1,0 +1,235 @@
+package org.opensilex.sparql.service;
+
+import org.apache.jena.arq.querybuilder.SelectBuilder;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.expr.E_GreaterThanOrEqual;
+import org.apache.jena.sparql.expr.E_LessThanOrEqual;
+import org.apache.jena.sparql.expr.E_LogicalAnd;
+import org.apache.jena.sparql.expr.Expr;
+import org.junit.Test;
+import org.opensilex.sparql.deserializer.SPARQLDeserializerNotFoundException;
+import org.opensilex.sparql.deserializer.SPARQLDeserializers;
+import org.opensilex.sparql.exceptions.SPARQLInvalidClassDefinitionException;
+import org.opensilex.sparql.exceptions.SPARQLMapperNotFoundException;
+import org.opensilex.sparql.model.SPARQLResourceModel;
+import test.opensilex.sparql.model.A;
+import test.opensilex.sparql.model.B;
+
+import javax.mail.internet.InternetAddress;
+import java.math.BigInteger;
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class SPARQLQueryHelperTest {
+
+    @Test
+    public void testGetURIField() throws SPARQLInvalidClassDefinitionException, SPARQLMapperNotFoundException {
+
+        Var aUriVar = SPARQLQueryHelper.getUriFieldVar(A.class);
+        assertEquals(aUriVar.getName(), SPARQLResourceModel.URI_FIELD);
+
+        Var bUriVar = SPARQLQueryHelper.getUriFieldVar(B.class);
+        assertEquals(bUriVar.getName(), SPARQLResourceModel.URI_FIELD);
+    }
+
+    @Test
+    public void testDateRange() throws Exception {
+
+        String startDateVar = "start";
+        String endDateVar = "end";
+        String startDateStr = "2020-01-06";
+        String endDateStr = "2020-02-05";
+
+        LocalDate startDate = LocalDate.parse(startDateStr);
+        LocalDate endDate = LocalDate.parse(endDateStr);
+
+        // test with null start and en<d date
+        Expr dateRange = SPARQLQueryHelper.dateRange(startDateVar, null, endDateVar, null);
+        assertNull(dateRange);
+
+        // test with null end date
+        dateRange = SPARQLQueryHelper.dateRange(startDateVar, startDate, endDateVar, null);
+        assertNotNull(dateRange);
+        assertTrue(dateRange instanceof E_GreaterThanOrEqual);
+        assertEquals(dateRange.toString(), "(>= ?start \"2020-01-06\"^^<http://www.w3.org/2001/XMLSchema#date>)");
+
+        // test with null start date
+        dateRange = SPARQLQueryHelper.dateRange(startDateVar, null, endDateVar, endDate);
+        assertNotNull(dateRange);
+        assertTrue(dateRange instanceof E_LessThanOrEqual);
+        assertEquals(dateRange.toString(), "(<= ?end \"2020-02-05\"^^<http://www.w3.org/2001/XMLSchema#date>)");
+
+        // test with two non null date
+        dateRange = SPARQLQueryHelper.dateRange(startDateVar, startDate, endDateVar, endDate);
+        assertNotNull(dateRange);
+        assertTrue(dateRange instanceof E_LogicalAnd);
+        assertEquals(dateRange.toString(), "(&& (>= ?start \"2020-01-06\"^^<http://www.w3.org/2001/XMLSchema#date>) (<= ?end \"2020-02-05\"^^<http://www.w3.org/2001/XMLSchema#date>))");
+
+        E_LogicalAnd and = (E_LogicalAnd) dateRange;
+        
+        Expr startDatePart = and.getArg1();
+        Expr endDatePart = and.getArg2();
+        assertTrue(startDatePart instanceof E_GreaterThanOrEqual);
+        assertTrue(endDatePart instanceof E_LessThanOrEqual);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testWhereValuesFailWithNullSelect() throws Exception {
+        SPARQLQueryHelper.addWhereValues(null, null, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testWhereValuesFailWithNullVarName() throws Exception {
+        SPARQLQueryHelper.addWhereValues(new SelectBuilder(), null, null);
+    }
+
+    @Test
+    public void testWhereValuesFailWithEmptyVarName() throws Exception {
+
+        SelectBuilder select = new SelectBuilder();
+        SPARQLQueryHelper.addWhereValues(select, "", Collections.emptyList());
+
+        Map<Var, List<Node>> whereValuesMap = select.getWhereValuesMap();
+        assertTrue(whereValuesMap.isEmpty());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testWhereValuesFailWithNullValues() throws Exception {
+        SPARQLQueryHelper.addWhereValues(new SelectBuilder(), "var", null);
+    }
+
+    protected void testWhereValues(SelectBuilder select, Node var, List<?> objs) throws Exception {
+
+        SPARQLQueryHelper.addWhereValues(select, var.getName(), objs);
+        Map<Var, List<Node>> whereValuesMap = select.getWhereValuesMap();
+
+        // test that the VALUES claude has been created
+        assertTrue(whereValuesMap.containsKey(var));
+        List<Node> nodeList = whereValuesMap.get(var);
+
+        // test that each Object from objs is present in nodeList
+        for (Object obj : objs) {
+            Node node = SPARQLDeserializers.getForClass(obj.getClass()).getNodeFromString(obj.toString());
+            assertTrue(nodeList.contains(node));
+        }
+    }
+
+    @Test
+    public void testWhereValuesWithURI() throws Exception {
+
+        List<URI> uris = Arrays.asList(
+            new URI("http://opensilex.org/set/experiments/xp"),
+            new URI("http://opensilex.org/set/experiments/xp1"),
+            new URI("rdf:type"),
+            new URI("rdfs:class")
+        );
+        testWhereValues(new SelectBuilder(), NodeFactory.createVariable("experiment"), uris);
+    }
+
+    @Test
+    public void testWhereValuesWithStr() throws Exception {
+        List<String> strings = Arrays.asList("Agrophen", "Diaphen", "Phenoarch");
+        testWhereValues(new SelectBuilder(), NodeFactory.createVariable("label"), strings);
+    }
+
+    @Test
+    public void testWhereValuesWitBooleanDataTypes() throws Exception {
+        List<Boolean> booleans = Arrays.asList(Boolean.TRUE, Boolean.FALSE, Boolean.FALSE, Boolean.TRUE);
+        testWhereValues(new SelectBuilder(), NodeFactory.createVariable("hasBoolean"), booleans);
+    }
+
+    @Test
+    public void testWhereValuesWithNumberDataTypes() throws Exception {
+
+        List<Integer> integers = Arrays.asList(58, 147, 63);
+        testWhereValues(new SelectBuilder(), NodeFactory.createVariable("hasInt"), integers);
+
+        List<Long> longs = Arrays.asList(584888648L, 1474864884L, 63165333458648L);
+        testWhereValues(new SelectBuilder(), NodeFactory.createVariable("hasLong"), longs);
+
+        List<Short> shorts = Arrays.asList((short) 5, (short) 47, (short) 32);
+        testWhereValues(new SelectBuilder(), NodeFactory.createVariable("hasShort"), shorts);
+
+        List<Double> doubles = Arrays.asList(1234.5, 3.14, 890.6, 448614.9744, 8e6);
+        testWhereValues(new SelectBuilder(), NodeFactory.createVariable("hasDouble"), doubles);
+
+        List<Float> floats = Arrays.asList(1234.5f, 3.14f, 890.6e14f, 448614.9744f, 8e16f);
+        testWhereValues(new SelectBuilder(), NodeFactory.createVariable("hasFloat"), floats);
+
+        List<BigInteger> bigIntegers = Arrays.asList(
+            new BigInteger("49888881998416616565888888888448748751114797"),
+            new BigInteger("2434718947848647864635429020081766404878459000"),
+            new BigInteger("2434718947848647864635429020081766404878459000").multiply(new BigInteger("78948647446"))
+        );
+        testWhereValues(new SelectBuilder(), NodeFactory.createVariable("hasBigInt"), bigIntegers);
+
+    }
+
+    @Test
+    public void testWhereValuesWithEmail() throws Exception {
+
+        List<InternetAddress> addresses = Arrays.asList(
+            InternetAddress.parse("abc@abc.com, admin@opensilex.org, opensilex@inrae.fr")
+        );
+        testWhereValues(new SelectBuilder(), NodeFactory.createVariable("hasMail"), addresses);
+    }
+
+    @Test
+    public void testWhereValuesWithByte() throws Exception {
+
+        List<Byte> byteList = Arrays.asList((byte) 24, (byte) 96, (byte) -124, (byte) 127, (byte) -128, (byte) 5);
+        testWhereValues(new SelectBuilder(), NodeFactory.createVariable("hasByte"), byteList);
+
+        String str = "some str which will be converted to byte[] 4 44978df";
+        List<Byte> byteListFromStr = new ArrayList<>(str.length());
+        for (byte b : str.getBytes())
+            byteListFromStr.add(b);
+        testWhereValues(new SelectBuilder(), NodeFactory.createVariable("hasByte"), byteListFromStr);
+    }
+
+    @Test
+    public void testWhereValuesWithChar() throws Exception {
+
+        String str = "some str which will be converted to byte[] 4 44978df";
+        List<Character> chars = new ArrayList<>(str.length());
+        for (int i = 0; i < str.length(); i++)
+            chars.add(str.charAt(i));
+        testWhereValues(new SelectBuilder(), NodeFactory.createVariable("hasChar"), chars);
+    }
+
+
+    @Test
+    public void testWhereValuesWithDateTypes() throws Exception {
+
+        List<LocalDate> dates = Arrays.asList(
+            LocalDate.now(),
+            LocalDate.now().plusDays(50),
+            LocalDate.now().minusMonths(4)
+        );
+        testWhereValues(new SelectBuilder(), NodeFactory.createVariable("hasDate"), dates);
+
+        List<OffsetDateTime> dataTimes = Arrays.asList(
+            OffsetDateTime.parse("2011-12-03T10:15:30+01:00"),
+            OffsetDateTime.now(),
+            OffsetDateTime.of(2020, 4, 28, 14, 32, 58, 0, ZoneOffset.ofHours(1))
+        );
+        testWhereValues(new SelectBuilder(), NodeFactory.createVariable("hasDateTime"), dataTimes);
+    }
+
+    @Test(expected = SPARQLDeserializerNotFoundException.class)
+    public void testWhereValueWithUnknownType() throws Exception {
+
+        List<Set<String>> setList = new ArrayList<>();
+        setList.add(new HashSet<>());
+        setList.get(0).addAll(Arrays.asList("str1", "str2"));
+
+        testWhereValues(new SelectBuilder(), NodeFactory.createVariable("hasSet"), setList);
+    }
+}

--- a/opensilex-sparql/src/test/java/org/opensilex/sparql/service/SPARQLQueryHelperTest.java
+++ b/opensilex-sparql/src/test/java/org/opensilex/sparql/service/SPARQLQueryHelperTest.java
@@ -80,29 +80,20 @@ public class SPARQLQueryHelperTest {
         assertTrue(endDatePart instanceof E_LessThanOrEqual);
     }
 
-    @Test(expected = NullPointerException.class)
-    public void testWhereValuesFailWithNullSelect() throws Exception {
-        SPARQLQueryHelper.addWhereValues(null, null, null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testWhereValuesFailWithNullVarName() throws Exception {
-        SPARQLQueryHelper.addWhereValues(new SelectBuilder(), null, null);
-    }
-
     @Test
-    public void testWhereValuesFailWithEmptyVarName() throws Exception {
+    public void testWhereValuesFailWithEmptyParams() throws Exception {
 
         SelectBuilder select = new SelectBuilder();
         SPARQLQueryHelper.addWhereValues(select, "", Collections.emptyList());
 
         Map<Var, List<Node>> whereValuesMap = select.getWhereValuesMap();
         assertTrue(whereValuesMap.isEmpty());
-    }
 
-    @Test(expected = NullPointerException.class)
-    public void testWhereValuesFailWithNullValues() throws Exception {
-        SPARQLQueryHelper.addWhereValues(new SelectBuilder(), "var", null);
+        select = new SelectBuilder();
+        SPARQLQueryHelper.addWhereValues(select, "varName", Collections.emptyList());
+
+        whereValuesMap = select.getWhereValuesMap();
+        assertTrue(whereValuesMap.isEmpty());
     }
 
     protected void testWhereValues(SelectBuilder select, Node var, List<?> objs) throws Exception {


### PR DESCRIPTION
Into `SPARQLQueryHelper` : 

- add the `dateRange(String startDateSparqlVarName, LocalDate startDate, String endDateSparqlVarName, LocalDate endDate)` method which allow to build an `Expr` from two `LocalDate` and two SPARQL variable names. 
- add the `addWhereValues(SelectBuilder select, String sparqlVarName, List<?> values)` which allow to update a `SelectBuilder` by adding a WHERE { ?var } VALUES { value_1 value_2 .. value_n } clause. 
- add the `eq(String sparqlVarName, Object object)` and `eq(String sparqlVarName, Node node) ` methods, these methods return an `E_Equals` jena expression between the given variable name and the given object/object node. 


Add corresponding unit tests method and a test for the `SPARQLQueryHelper.getUriFieldVar(Class<T> objectClass)` method into the `SPARQLQueryHelperTest` class